### PR TITLE
changed /usr/bin/env to /usr/bin/env python

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from datetime import datetime, date
 import time
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Using /usr/bin/env/ in python serves one more purpose. As python supports virtual environments, using /usr/bin/env python will make sure that your scripts runs inside the virtual environment, if you are inside one. Whereas, /usr/bin/python will run outside the virtual environment.